### PR TITLE
Added uname stuff to system info

### DIFF
--- a/bin/pdagentd.py
+++ b/bin/pdagentd.py
@@ -250,11 +250,18 @@ def run():
 
         # Get some basic system stats to post back in phone-home
         main_logger.debug('Collecting basic system stats')
+
+        # Pull uname-type system information
+        (sysname, node_name, release, version, machine, processor) = platform.uname()
         system_stats = {
             'platform_name': sys.platform,
+            'platform_release': release,
+            'platform_version': version,
+            'platform_machine': machine,
             'python_version': platform.python_version(),
             'host_name': socket.getfqdn()  # to show in stats-based alerts.
             }
+
         if sys.platform == 'linux2':
             system_stats['platform_version'] = platform.dist()
         main_logger.info('System: ' + str(system_stats))


### PR DESCRIPTION
This is a tiny PR.  `platform.uname()` pretty much returns `uname -a` as a tuple, so I just added the fields with "reasonable" names here.  If these names were already determined, or if better ones exist, let me know.

PS I plugged the Legoland endpoint in (and changed HeartbeatTask._urllib2 to urllib2 because the SSL cert is illegit) and the checkins work!

@anitarao @divtxt 
