### PR TITLE
Handle bad event filenames in dequeue @anitarao @chamblin @kenrose @rduffield

### DIFF
--- a/pdagent/pdqueue.py
+++ b/pdagent/pdqueue.py
@@ -471,9 +471,12 @@ class _BadFileNameError(Exception):
 
 
 def _get_event_metadata(fname):
+    if not fname.endswith(".txt"):
+        raise _BadFileNameError
+    fname = fname[:-4]
     try:
         event_type, enqueue_time_microsec_str, service_key = \
-            fname.split('.')[0].split('_', 2)
+            fname.split('_', 2)
         enqueue_time = int(enqueue_time_microsec_str) / (1000 * 1000)
         return event_type, enqueue_time, service_key
     except ValueError:

--- a/pdagenttest/test_pdqueue.py
+++ b/pdagenttest/test_pdqueue.py
@@ -241,13 +241,13 @@ class PDQueueTest(unittest.TestCase):
         self.assertEquals(
             q._queued_files("suc_"),
             [
-                "suc_0_noextension",
                 f_foo.replace("pdq_", "suc_"),
                 ]
             )
         self.assertEquals(
             q._queued_files("err_"),
             [
+                "err_0_noextension",
                 "err_notenoughunderscores.txt",
                 "err_notint_servicekey.txt",
                 ]


### PR DESCRIPTION
A badly named event will bock the agent dequeue & heartbeat via queue stats.  Fix this!

@anitarao @chamblin @kenrose @rduffield 
