### PR TITLE
sudo is broken for initscripts when requiretty is set (as is default)

### DIFF
--- a/build-linux/init-script.sh
+++ b/build-linux/init-script.sh
@@ -80,7 +80,7 @@ start() {
   echo -n "Starting: pdagent"
   setup
   is_running || {
-    su pdagent $EXEC
+    su -s /bin/bash -c "$EXEC" pdagent
     [ $? -eq 0 ] || return $?
   }
   echo "."


### PR DESCRIPTION
1. You should never have to use su or sudo in an init script to do things as root -- init scripts are meant to be run **as** root
2. sudo may not be present on the instance, and your package doesn't include it as a requirement
3. switching user to run as pdagent can be achieved via `su` which is always present on the base image
4. `sudo` breaks when `requiretty` is set -- as is the default in CentOS 6.5, Amazon Linux AMI, etc. etc. -- this means that starting pdagent via `cfn-init`, for example, will break.
