### PR TITLE
RI-179 Make agent work on CentOS 7

### DIFF
--- a/build-linux/make_package.sh
+++ b/build-linux/make_package.sh
@@ -94,7 +94,8 @@ chmod 755 data/etc/init.d/pdagent
 if [ "$pkg_type" = "deb" ]; then
     _PY_SITE_PACKAGES=data/usr/share/pyshared
 else
-    _PY_SITE_PACKAGES=data/usr/share/pdagent/lib
+    _PY_SITE_PACKAGES=data/usr/lib/python2.6/site-packages
+    _PY27_SITE_PACKAGES=data/usr/lib/python2.7/site-packages
 fi
 
 echo = python modules...
@@ -113,6 +114,12 @@ if [ "$pkg_type" = "deb" ]; then
     echo >> $_PD_PUBLIC
     find $_PY_SITE_PACKAGES -type f -name "*.py" | cut -c 5- >> $_PD_PUBLIC
     find $_PY_SITE_PACKAGES -type f -name "ca_certs.pem" | cut -c 5- >> $_PD_PUBLIC
+fi
+
+# copy the libraries for python2.7 rpm users
+if [ "$pkg_type" = "rpm" ]; then
+    mkdir -p "$_PY27_SITE_PACKAGES"
+    cp -r $_PY_SITE_PACKAGES/* "$_PY27_SITE_PACKAGES"
 fi
 
 echo = FPM!

--- a/build-linux/rpm/postinst
+++ b/build-linux/rpm/postinst
@@ -44,12 +44,10 @@ chmod 753 /var/lib/pdagent/outqueue/tmp /var/lib/pdagent/outqueue/pdq
 
 VERSION=`python -c "import platform; print platform.python_version()"`
 if [[ $VERSION == 2.7.* ]]; then
-	INSTALL_PATH="/usr/lib/python2.7/site-packages/pdagent"
+    INSTALL_PATH="/usr/lib/python2.7/site-packages/pdagent"
 else
-	INSTALL_PATH="/usr/lib/python2.6/site-packages/pdagent"
+    INSTALL_PATH="/usr/lib/python2.6/site-packages/pdagent"
 fi
-
-ln -s /usr/share/pdagent/lib/pdagent $INSTALL_PATH
 
 # Compile module .py to .pyc
 python -m compileall -q -f "$INSTALL_PATH/"


### PR DESCRIPTION
CentOS 7 is pretty new, but it uses Python 2.7 and does not have any Python paths in common with 2.6.  So, post-install, we will check for the presence of a python2.7 lib directory and symlink it there.

Only the 64 bit version is available (as far as I can tell), so that's what I manually tested this on.  There are a few Vagrant images, but none of them work, so I was unable to add integration tests for now, until CentOS 7 is a bit more mainstream.

Do you mind taking a look at this @divtxt ?
