### PR TITLE
Add a quick foreground flag.

### DIFF
--- a/bin/pdagentd.py
+++ b/bin/pdagentd.py
@@ -404,6 +404,6 @@ def init_logging(log_dir):
 
 
 # ---- Daemonize and run agent
-
-daemonize(pidfile, umask=_DEFAULT_UMASK)
+if not (len(sys.argv) > 1 and sys.argv[1] == '-f'):
+    daemonize(pidfile, umask=_DEFAULT_UMASK)
 run()


### PR DESCRIPTION
If we get more command line arguments, we need to add a proper
getopts setup, but for now this suffices.

Should satisfy https://github.com/PagerDuty/pdagent/issues/92
