### PR TITLE
Support Ubuntu 16.04 #98

### DIFF
--- a/build-linux/deb/postinst
+++ b/build-linux/deb/postinst
@@ -45,9 +45,7 @@ if [ "$1" = "configure" ]; then
     chmod 753 /var/lib/pdagent/outqueue/tmp /var/lib/pdagent/outqueue/pdq
 
     # Compile module .py to .pyc
-    if which update-python-modules >/dev/null 2>&1; then
-        update-python-modules python-pdagent.public
-    fi
+    pycompile -p pdagent
 
     # Register daemon
     update-rc.d -f pdagent defaults

--- a/build-linux/deb/prerm
+++ b/build-linux/deb/prerm
@@ -38,9 +38,7 @@ if [ "$1" = "remove" ]; then  # remove-only; not upgrade.
     update-rc.d -f pdagent remove
 
     # Clean up module .pyc
-    if which update-python-modules >/dev/null 2>&1; then
-        update-python-modules -c python-pdagent.public
-    fi
+    pyclean -p pdagent
 fi
 
 exit 0

--- a/build-linux/make_deb.sh
+++ b/build-linux/make_deb.sh
@@ -44,10 +44,10 @@ install_root="$2"
 deb_install_root=$install_root/deb
 [ -d "$deb_install_root" ] || mkdir -p $deb_install_root
 
-[ $(sudo dpkg -l ruby-dev rubygems | grep -c '^i') -eq 2 ] || {
+[ $(sudo dpkg -l ruby-dev rubygems libffi-dev | grep -c '^i') -eq 3 ] || {
     echo "Installing required packages. This may take a few minutes..."
     sudo apt-get update -qq
-    sudo apt-get install -y -q ruby-dev rubygems
+    sudo apt-get install -y -q ruby-dev rubygems libffi-dev
     echo "Done installing."
 }
 { gem list fpm | grep fpm >/dev/null ; } || {

--- a/build-linux/make_package.sh
+++ b/build-linux/make_package.sh
@@ -92,7 +92,7 @@ cp init-script.sh data/etc/init.d/pdagent
 chmod 755 data/etc/init.d/pdagent
 
 if [ "$pkg_type" = "deb" ]; then
-    _PY_SITE_PACKAGES=data/usr/share/pyshared
+    _PY_SITE_PACKAGES=data/usr/lib/python2.7/dist-packages
 else
     _PY_SITE_PACKAGES=data/usr/lib/python2.6/site-packages
     _PY27_SITE_PACKAGES=data/usr/lib/python2.7/site-packages
@@ -106,16 +106,6 @@ find pdagent -type f \( -name "*.py" -o -name "ca_certs.pem" \) \
     -exec cp {} build-linux/$_PY_SITE_PACKAGES/{} \;
 cd -
 
-if [ "$pkg_type" = "deb" ]; then
-    echo = deb python-support...
-    mkdir -p data/usr/share/python-support
-    _PD_PUBLIC=data/usr/share/python-support/python-pdagent.public
-    echo pyversions=2.6- > $_PD_PUBLIC
-    echo >> $_PD_PUBLIC
-    find $_PY_SITE_PACKAGES -type f -name "*.py" | cut -c 5- >> $_PD_PUBLIC
-    find $_PY_SITE_PACKAGES -type f -name "ca_certs.pem" | cut -c 5- >> $_PD_PUBLIC
-fi
-
 # copy the libraries for python2.7 rpm users
 if [ "$pkg_type" = "rpm" ]; then
     mkdir -p "$_PY27_SITE_PACKAGES"
@@ -124,9 +114,6 @@ fi
 
 echo = FPM!
 _FPM_DEPENDS="--depends sudo --depends python"
-if [ "$pkg_type" = "deb" ]; then
-    _FPM_DEPENDS="$_FPM_DEPENDS --depends python-support"
-fi
 
 _SIGN_OPTS=""
 if [ "$pkg_type" = "rpm" ]; then


### PR DESCRIPTION
I can't speak to backwards compatibility on this. These changes allow the PagerDuty agent to install on Ubuntu 16.04. The init.d script still works.
