### PR TITLE
Truncate description field to 1024

### DIFF
--- a/pdagent/pdagentutil.py
+++ b/pdagent/pdagentutil.py
@@ -108,7 +108,7 @@ def _build_event_json_str(
     if incident_key is not None:
         d["incident_key"] = incident_key
     if description is not None:
-        d["description"] = description
+        d["description"] = description[:1024]
     if client is not None:
         d["client"] = client
     if client_url is not None:


### PR DESCRIPTION
The PagerDuty API only supports a 1024 char description so requests will error out if longer.  This fix will truncate the description field to 1024 so should hopefully prevent long messages from getting infinitely stuck in the error queue.

If anyone's listening BTW, I really think the API should truncate it itself rather than throwing an error, but that's a different story...