### PR TITLE
Added -m flag to pass env variables to the daemon

### DIFF
--- a/build-linux/pdagent.init
+++ b/build-linux/pdagent.init
@@ -80,7 +80,7 @@ start() {
   echo -n "Starting: pdagent"
   setup
   is_running || {
-    su -s /bin/bash -c "$EXEC" pdagent
+    su -ms /bin/bash -c "$EXEC" pdagent
     [ $? -eq 0 ] || return $?
   }
   echo "."


### PR DESCRIPTION
In our documentation, it states that if using on a SysV init-based system, and
configuring the agent to use a proxy, the proxy environment variables should be
hard-coded into the init script. However, because su is not called with the
-m/-p flag, the environment variables within the parent thread from which it is
called are not preserved.

Adding this flag makes it so that any environment variables export-ed locally
within the script are passed along to pdagent.