### PR TITLE
Removed unsafe -m flag from su in init script

### DIFF
--- a/build-linux/pdagent.init
+++ b/build-linux/pdagent.init
@@ -80,7 +80,7 @@ start() {
   echo -n "Starting: pdagent"
   setup
   is_running || {
-    su -ms /bin/bash -c "$EXEC" pdagent
+    su -s /bin/bash -c "$EXEC" pdagent
     [ $? -eq 0 ] || return $?
   }
   echo "."


### PR DESCRIPTION
The flag was removed because it is potentially unsafe.

Per the BSD man page of su(1), if the target user's shell is not a standard login shell (which may apply for a "system user" as which pdagent runs), su will fail.