### PR TITLE
Fix for unbuffered IO failing under certain python/OS combos.

### DIFF
--- a/pdagent/thirdparty/daemon.py
+++ b/pdagent/thirdparty/daemon.py
@@ -94,7 +94,7 @@ def _redirect_std_file_descriptors(stdin, stdout, stderr):
     sys.stderr.flush()
     si = open(stdin, 'r')
     so = open(stdout, 'a+')
-    se = open(stderr, 'a+', 0)
+    se = open(stderr, 'a+')
     os.dup2(si.fileno(), sys.stdin.fileno())
     os.dup2(so.fileno(), sys.stdout.fileno())
     os.dup2(se.fileno(), sys.stderr.fileno())


### PR DESCRIPTION
In particular noticed this using Python 3.7 on Ubuntu 16.06. Unclear why buffering was required to begin with, but unlikely to be a critical requirement.