### PR TITLE
[DECO-1290] Dockerfiles - Ubuntu and CentOS

### DIFF
--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,0 +1,32 @@
+FROM centos/systemd
+
+ARG FPM_VERSION=1.11.0
+ARG PYTHON_VERSION=3
+ENV PYTHON_VERSION ${PYTHON_VERSION}
+
+RUN mkdir /pdagent
+WORKDIR /pdagent
+
+RUN yum install -y -q centos-release-scl
+RUN yum install -y -q createrepo
+RUN yum install -y -q gcc
+RUN yum install -y -q gcc-c++
+RUN yum install -y -q kernel-devel
+RUN yum install -y -q make
+RUN yum install -y -q rpm-build
+RUN yum install -y -q rh-ruby23
+RUN yum install -y -q rh-ruby23-ruby-devel
+RUN yum install -y -q sudo
+
+RUN source /opt/rh/rh-ruby23/enable && \
+  /opt/rh/rh-ruby23/root/usr/bin/gem install -q --no-ri --no-rdoc -v $FPM_VERSION fpm
+RUN yum install -y python${PYTHON_VERSION}
+
+COPY . /pdagent
+
+RUN useradd --create-home --shell /bin/bash pdagent \
+  && chown -R pdagent /pdagent \
+  # Primarily for handling sudo use during build and testing.
+  && echo "pdagent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# CMD python${PYTHON_VERSION} bin/pdagentd.py -f

--- a/Dockerfile-centos-7
+++ b/Dockerfile-centos-7
@@ -4,8 +4,8 @@ ARG FPM_VERSION=1.11.0
 ARG PYTHON_VERSION=3
 ENV PYTHON_VERSION ${PYTHON_VERSION}
 
-RUN mkdir /pdagent
-WORKDIR /pdagent
+RUN mkdir -p /usr/share/pdagent
+WORKDIR /usr/share/pdagent
 
 RUN yum install -y -q centos-release-scl
 RUN yum install -y -q createrepo
@@ -22,11 +22,14 @@ RUN source /opt/rh/rh-ruby23/enable && \
   /opt/rh/rh-ruby23/root/usr/bin/gem install -q --no-ri --no-rdoc -v $FPM_VERSION fpm
 RUN yum install -y python${PYTHON_VERSION}
 
-COPY . /pdagent
+COPY . /usr/share/pdagent
+RUN cp /usr/share/pdagent/build-linux/pdagent.service /lib/systemd/system
 
 RUN useradd --create-home --shell /bin/bash pdagent \
-  && chown -R pdagent /pdagent \
+  && chown -R pdagent /usr/share/pdagent \
   # Primarily for handling sudo use during build and testing.
   && echo "pdagent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# CMD python${PYTHON_VERSION} bin/pdagentd.py -f
+RUN systemctl enable pdagent
+
+CMD ["/usr/sbin/init"]

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -1,0 +1,59 @@
+ARG UBUNTU_VERSION=16.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG FPM_VERSION=1.11.0
+ARG PYTHON_VERSION=3
+ENV PYTHON_VERSION ${PYTHON_VERSION}
+ENV container docker
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN mkdir -p /usr/share/pdagent
+WORKDIR /usr/share/pdagent
+
+RUN apt-get update -y -qq
+RUN apt-get install -y -q apt-utils
+RUN apt-get install -y -q build-essential
+RUN apt-get install -y -q ca-certificates
+RUN apt-get install -y -q python-software-properties
+RUN apt-get install -y -q ruby2.3
+RUN apt-get install -y -q ruby2.3-dev
+RUN apt-get install -y -q software-properties-common
+RUN apt-get install -y -q sudo
+RUN update-ca-certificates
+
+RUN gem install -q --no-ri --no-rdoc -v ${FPM_VERSION} fpm
+RUN apt-get install -y -q python${PYTHON_VERSION}
+
+COPY . /usr/share/pdagent
+RUN cp /usr/share/pdagent/build-linux/pdagent.service /lib/systemd/system
+
+RUN useradd --create-home --shell /bin/bash pdagent \
+  && chown -R pdagent /usr/share/pdagent \
+  # Primarily for handling sudo use during build and testing.
+  && echo "pdagent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+RUN apt-get update \
+    && apt-get install -y systemd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN cd /lib/systemd/system/sysinit.target.wants/ \
+    && ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1
+
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/basic.target.wants/* \
+    /lib/systemd/system/anaconda.target.wants/* \
+    /lib/systemd/system/plymouth* \
+    /lib/systemd/system/systemd-update-utmp*
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+RUN systemctl enable pdagent
+
+CMD ["/lib/systemd/systemd"]
+
+#CMD python${PYTHON_VERSION} bin/pdagentd.py -f

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -55,5 +55,3 @@ VOLUME [ "/sys/fs/cgroup" ]
 RUN systemctl enable pdagent
 
 CMD ["/lib/systemd/systemd"]
-
-#CMD python${PYTHON_VERSION} bin/pdagentd.py -f

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,6 @@ ubuntu: target/deb target/tmp/GPG-KEY-pagerduty
 
 centos: target/rpm target/tmp/GPG-KEY-pagerduty
 
-run-%-console: run-%
-	docker exec \
-	-it $(docker ps -q -f ancestor=pdagent-$*) /bin/bash
-
-run-ubuntu: build-ubuntu
-	docker run \
-		--privileged \
-		-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-		-it pdagent-ubuntu
-
 build-ubuntu:
 	docker build . \
 		-t pdagent-ubuntu \
@@ -26,15 +16,6 @@ build-ubuntu:
 		--build-arg FPM_VERSION="${FPM_VERSION}" \
 		--build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
 		--build-arg UBUNTU_VERSION="${UBUNTU_VERSION}"
-
-run-centos: build-centos
-	docker run \
-		-p 5000:80 \
-		--privileged=true \
-		--tmpfs /tmp \
-		--tmpfs /run \
-		-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-		-it pdagent-centos 
 
 build-centos:
 	docker build . \

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ ubuntu: target/deb target/tmp/GPG-KEY-pagerduty
 
 centos: target/rpm target/tmp/GPG-KEY-pagerduty
 
-run-ubuntu-console: run-ubuntu
+run-%-console: run-%
 	docker exec \
-	-it $(docker ps -q -f ancestor=pdagent-ubuntu) /bin/bash
+	-it $(docker ps -q -f ancestor=pdagent-$*) /bin/bash
 
 run-ubuntu: build-ubuntu
 	docker run \
@@ -26,10 +26,6 @@ build-ubuntu:
 		--build-arg FPM_VERSION="${FPM_VERSION}" \
 		--build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
 		--build-arg UBUNTU_VERSION="${UBUNTU_VERSION}"
-
-run-centos-console: run-centos
-	docker exec \
-	-it $(docker ps -q -f ancestor=pdagent-centos) /bin/bash
 
 run-centos: build-centos
 	docker run \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+include build-linux/make_common.env
+export $(shell sed 's/=.*//' build-linux/make_common.env)
+
+main: build
+
+build: ubuntu centos
+
+ubuntu: target/deb target/tmp/GPG-KEY-pagerduty
+
+centos: target/rpm target/tmp/GPG-KEY-pagerduty
+
+build-ubuntu:
+	docker build . \
+		-t pdagent-ubuntu \
+		-f Dockerfile-ubuntu \
+		--build-arg FPM_VERSION="${FPM_VERSION}" \
+		--build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+		--build-arg UBUNTU_VERSION="${UBUNTU_VERSION}"
+
+build-centos:
+	docker build . \
+		-t pdagent-centos \
+		-f Dockerfile-centos \
+		--build-arg FPM_VERSION="${FPM_VERSION}" \
+		--build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+		--build-arg CENTOS_VERSION="${CENTOS_VERSION}"
+
+target/deb: build-ubuntu
+	docker run \
+		-v `pwd`:/pdagent \
+		-it pdagent-ubuntu \
+			/bin/sh -c "/bin/sh build-linux/make_deb.sh /pdagent/tmp/gnupg /pdagent/target"
+
+target/rpm: build-centos
+	docker run \
+		-v `pwd`:/pdagent \
+		-it pdagent-centos \
+			/bin/sh -c "/bin/sh build-linux/make_rpm.sh /pdagent/tmp/gnupg /pdagent/target"
+
+target/tmp/GPG-KEY-pagerduty:
+	docker run \
+		-v `pwd`:/pdagent \
+		-it pdagent-ubuntu \
+			/bin/sh -c "mkdir -p /pdagent/target/tmp; gpg --armor --export --homedir /pdagent/tmp/gnupg > /pdagent/target/tmp/GPG-KEY-pagerduty"
+
+clean:
+	rm -rf dist
+	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ ubuntu: target/deb target/tmp/GPG-KEY-pagerduty
 
 centos: target/rpm target/tmp/GPG-KEY-pagerduty
 
+run-ubuntu-console: run-ubuntu
+	docker exec \
+	-it $(docker ps -q -f ancestor=pdagent-ubuntu) /bin/bash
+
+run-ubuntu: build-ubuntu
+	docker run \
+		--privileged \
+		-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+		-it pdagent-ubuntu
+
 build-ubuntu:
 	docker build . \
 		-t pdagent-ubuntu \
@@ -16,6 +26,19 @@ build-ubuntu:
 		--build-arg FPM_VERSION="${FPM_VERSION}" \
 		--build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
 		--build-arg UBUNTU_VERSION="${UBUNTU_VERSION}"
+
+run-centos-console: run-centos
+	docker exec \
+	-it $(docker ps -q -f ancestor=pdagent-centos) /bin/bash
+
+run-centos: build-centos
+	docker run \
+		-p 5000:80 \
+		--privileged=true \
+		--tmpfs /tmp \
+		--tmpfs /run \
+		-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+		-it pdagent-centos 
 
 build-centos:
 	docker build . \
@@ -46,3 +69,7 @@ target/tmp/GPG-KEY-pagerduty:
 clean:
 	rm -rf dist
 	rm -rf target
+
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,3 @@ target/tmp/GPG-KEY-pagerduty:
 clean:
 	rm -rf dist
 	rm -rf target
-
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-ubuntu:
 build-centos:
 	docker build . \
 		-t pdagent-centos \
-		-f Dockerfile-centos \
+		-f Dockerfile-centos-7 \
 		--build-arg FPM_VERSION="${FPM_VERSION}" \
 		--build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
 		--build-arg CENTOS_VERSION="${CENTOS_VERSION}"

--- a/build-linux/make_common.env
+++ b/build-linux/make_common.env
@@ -1,3 +1,7 @@
 ## common variables for make_* scripts
 
 FPM_VERSION=1.4.0
+CENTOS_VERSION=7
+FPM_VERSION=1.11.0
+PYTHON_VERSION=3
+UBUNTU_VERSION=16.04

--- a/scripts/run-console.sh
+++ b/scripts/run-console.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Usage: ./scripts/run-console.sh <ubuntu OR centos>
+
+OS=$1
+make build-${OS}
+if [ $OS == "ubuntu" ]
+then
+    docker run -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -it pdagent-ubuntu
+elif [ $OS == 'centos' ]
+then
+    docker run -d -p 5000:80 --privileged=true --tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro -it pdagent-centos 
+fi
+docker exec -it $(docker ps -q -f ancestor=pdagent-${OS}) /bin/bash


### PR DESCRIPTION
This PR adds Dockerfiles that run Ubuntu and CentOS with systemd which starts pdagent. Also added `make` commands so we don't have to remember the annoying docker commands. 

One interesting thing I haven't been able to figure out: at some point `ctrl + c` would kill the docker container, but now that doesn't work and you have to manually kill it. I tried removing `-t` from the docker commands to get rid of a pseudo TTY but that didn't work :/