### PR TITLE
Updating build scripts toward supporting Python 3.

### DIFF
--- a/Dockerfile-centos-7
+++ b/Dockerfile-centos-7
@@ -13,7 +13,10 @@ RUN yum install -y -q gcc
 RUN yum install -y -q gcc-c++
 RUN yum install -y -q kernel-devel
 RUN yum install -y -q make
+RUN yum install -y -q python27-python-pip
+RUN yum install -y -q python3-pip
 RUN yum install -y -q rpm-build
+RUN yum install -y -q rpm-sign
 RUN yum install -y -q rh-ruby23
 RUN yum install -y -q rh-ruby23-ruby-devel
 RUN yum install -y -q sudo

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -19,6 +19,10 @@ RUN apt-get install -y -q ruby2.3
 RUN apt-get install -y -q ruby2.3-dev
 RUN apt-get install -y -q software-properties-common
 RUN apt-get install -y -q sudo
+RUN apt-get install -y -q systemd
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 RUN update-ca-certificates
 
 RUN gem install -q --no-ri --no-rdoc -v ${FPM_VERSION} fpm
@@ -31,11 +35,6 @@ RUN useradd --create-home --shell /bin/bash pdagent \
   && chown -R pdagent /usr/share/pdagent \
   # Primarily for handling sudo use during build and testing.
   && echo "pdagent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-RUN apt-get update \
-    && apt-get install -y systemd \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN cd /lib/systemd/system/sysinit.target.wants/ \
     && ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1

--- a/Makefile
+++ b/Makefile
@@ -27,21 +27,21 @@ build-centos:
 
 target/deb: build-ubuntu
 	docker run \
-		-v `pwd`:/pdagent \
+		-v `pwd`:/usr/share/pdagent \
 		-it pdagent-ubuntu \
-			/bin/sh -c "/bin/sh build-linux/make_deb.sh /pdagent/tmp/gnupg /pdagent/target"
+			/bin/sh -c "/bin/sh build-linux/make_deb.sh /usr/share/pdagent/build-linux/gnupg /usr/share/pdagent/target"
 
 target/rpm: build-centos
 	docker run \
-		-v `pwd`:/pdagent \
+		-v `pwd`:/usr/share/pdagent \
 		-it pdagent-centos \
-			/bin/sh -c "/bin/sh build-linux/make_rpm.sh /pdagent/tmp/gnupg /pdagent/target"
+			/bin/sh -c "/bin/sh build-linux/make_rpm.sh /usr/share/pdagent/build-linux/gnupg /usr/share/pdagent/target"
 
 target/tmp/GPG-KEY-pagerduty:
 	docker run \
-		-v `pwd`:/pdagent \
+		-v `pwd`:/usr/share/pdagent \
 		-it pdagent-ubuntu \
-			/bin/sh -c "mkdir -p /pdagent/target/tmp; gpg --armor --export --homedir /pdagent/tmp/gnupg > /pdagent/target/tmp/GPG-KEY-pagerduty"
+			/bin/sh -c "mkdir -p /usr/share/pdagent/target/tmp; gpg --armor --export --homedir /usr/share/pdagent/build-linux/gnupg > /usr/share/pdagent/target/tmp/GPG-KEY-pagerduty"
 
 clean:
 	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -83,13 +83,12 @@ Agent with the following steps:
 
 1. Configure signing keys by following the [One-time setup of GPG keys](build-linux/howto.md#one-time-setup-of-gpg-keys) instructions.
 
+
 2. Run the following commands:
 ```
-scons --clean
-scons local-repo gpg-home=build-linux/gnupg
+make ubuntu
+make centos
 ```
-Note that this will spin up multiple virtual machines using Vagrant to run
-tests and perform builds on.
 
 3. Run integration tests on the packages as follows:
   * Edit the file `pdagenttestinteg/util.sh` and change the line `SVC_KEY=CHANGEME` to a real PagerDuty Service API Key in your pdt test account.

--- a/build-linux/make_common.env
+++ b/build-linux/make_common.env
@@ -1,6 +1,5 @@
 ## common variables for make_* scripts
 
-FPM_VERSION=1.4.0
 CENTOS_VERSION=7
 FPM_VERSION=1.11.0
 PYTHON_VERSION=3

--- a/build-linux/make_deb.sh
+++ b/build-linux/make_deb.sh
@@ -38,6 +38,8 @@ cd $basedir
 # source common variables
 . ./make_common.env
 
+mkdir -p $2
+
 if [ -z "$1" -o -z "$2" -o ! -d "$1" -o ! -d "$2" ]; then
     echo "Usage: $0 {path-to-gpg-home} {path-to-package-installation-root}"
     exit 2
@@ -46,26 +48,6 @@ gpg_home="$1"
 install_root="$2"
 deb_install_root=$install_root/deb
 [ -d "$deb_install_root" ] || mkdir -p $deb_install_root
-
-# update packages
-sudo apt-get update -qq
-
-# install build tools
-sudo apt-get install -y build-essential
-
-[ $(sudo dpkg -l ruby2.3-dev | grep -c '^i') -eq 2 ] || {
-    echo "Installing required packages. This may take a few minutes..."
-    sudo apt-get install -y -q python-software-properties
-    sudo add-apt-repository -y ppa:brightbox/ruby-ng-experimental
-    sudo apt-get update -qq
-    sudo apt-get install -y -q ruby2.3 ruby2.3-dev
-    echo "Done installing."
-}
-{ gem list fpm | grep fpm >/dev/null ; } || {
-    echo "Installing fpm gem..."
-    sudo gem install -q -v $FPM_VERSION fpm
-    echo "Done installing."
-}
 
 sh make_package.sh deb
 

--- a/build-linux/make_package.sh
+++ b/build-linux/make_package.sh
@@ -96,24 +96,30 @@ mkdir -p data/etc/
 cp ../conf/pdagent.conf data/etc/
 
 if [ "$pkg_type" = "deb" ]; then
-    _PY_SITE_PACKAGES=data/usr/lib/python2.7/dist-packages
+    _PY27_SITE_PACKAGES=data/usr/lib/python2.7/dist-packages
+    _PY3_SITE_PACKAGES=data//usr/lib/python3/dist-packages
 else
-    _PY_SITE_PACKAGES=data/usr/lib/python2.6/site-packages
     _PY27_SITE_PACKAGES=data/usr/lib/python2.7/site-packages
+    _PY36_SITE_PACKAGES=data/usr/lib/python3.6/site-packages
+    _PY37_SITE_PACKAGES=data/usr/lib/python3.7/site-packages
 fi
 
 echo = python modules...
-mkdir -p $_PY_SITE_PACKAGES
+mkdir -p $_PY27_SITE_PACKAGES
 cd ..
-find pdagent -type d -exec mkdir -p build-linux/$_PY_SITE_PACKAGES/{} \;
+find pdagent -type d -exec mkdir -p build-linux/$_PY27_SITE_PACKAGES/{} \;
 find pdagent -type f \( -name "*.py" -o -name "ca_certs.pem" \) \
-    -exec cp {} build-linux/$_PY_SITE_PACKAGES/{} \;
+    -exec cp {} build-linux/$_PY27_SITE_PACKAGES/{} \;
 cd -
 
-# copy the libraries for python2.7 rpm users
-if [ "$pkg_type" = "rpm" ]; then
-    mkdir -p "$_PY27_SITE_PACKAGES"
-    cp -r $_PY_SITE_PACKAGES/* "$_PY27_SITE_PACKAGES"
+if [ "$pkg_type" = "deb" ]; then
+    mkdir -p "$_PY3_SITE_PACKAGES"
+    cp -r $_PY27_SITE_PACKAGES/* "$_PY3_SITE_PACKAGES"
+else
+    mkdir -p "$_PY36_SITE_PACKAGES"
+    cp -r $_PY27_SITE_PACKAGES/* "$_PY36_SITE_PACKAGES"
+    mkdir -p "$_PY37_SITE_PACKAGES"
+    cp -r $_PY27_SITE_PACKAGES/* "$_PY37_SITE_PACKAGES"
 fi
 
 echo = FPM!

--- a/build-linux/make_rpm.sh
+++ b/build-linux/make_rpm.sh
@@ -38,6 +38,8 @@ cd $basedir
 # source common variables
 . ./make_common.env
 
+mkdir -p $2
+
 if [ -z "$1" -o -z "$2" -o ! -d "$1" -o ! -d "$2" ]; then
     echo "Usage: $0 {path-to-gpg-home} {path-to-package-installation-root}"
     exit 2
@@ -46,24 +48,6 @@ gpg_home="$1"
 install_root="$2"
 rpm_install_root=$install_root/rpm
 [ -d "$rpm_install_root" ] || mkdir -p $rpm_install_root
-
-# install required packages.
-[ $(sudo rpm -q rpm-build rh-ruby23 createrepo \
-        gcc gcc-c++ kernel-devel | \
-        grep -vc 'not installed') -eq 7 ] || {
-    echo "Installing required packages. This may take a few minutes..."
-    sudo yum install -y -q rpm-build createrepo gcc gcc-c++ kernel-devel
-    sudo yum install -y -q centos-release-scl
-    sudo yum install -y -q rh-ruby23 rh-ruby23-ruby-devel
-}
-
-source /opt/rh/rh-ruby23/enable
-
-{ sudo /opt/rh/rh-ruby23/root/usr/bin/gem list fpm | grep fpm >/dev/null ; } || {
-    echo "Installing fpm gem..."
-    sudo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" /opt/rh/rh-ruby23/root/usr/bin/gem install -q -v $FPM_VERSION fpm
-    echo "Done installing."
-}
 
 echo "Setting up GPG information for RPM..."
 # fingerprint to use for signing = first fingerprint in GPG keyring


### PR DESCRIPTION
Updates to our build process to support Python 3 and the new Docker/Makefile setup.

There's still some fiddliness around distro paths: With Python 2 we only had to concern ourselves with installing for Python 2.6 and 2.7 so two sets of `site-packages`, but have potentially more for Python 3 on platforms that split `site-packages` by minor version. Can investigate more in subsequent passes.