### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The supported events are those listed in the PagerDuty Integration API:
 The PagerDuty Agent is completely open-source which means that you can download
 the source code and customize it for your needs.
 
-The Agent requires Python 2.6 or 2.7. The instructions here assume that you're
+The Agent requires Python 2.7 or higher. The instructions here assume that you're
 on a Mac.
 
 ## Developing


### PR DESCRIPTION
Due to a recent update: https://github.com/PagerDuty/pdagent/blame/f2f8766d82043ecbf6b055510e638fae5eae0988/bin/pdagentd.py#L60 pdagent is required to run on Python 2.7 or higher.