### PR TITLE
fix issue when in 'pd-queue status', when a intgeration key is throttled

### DIFF
--- a/bin/pd-queue
+++ b/bin/pd-queue
@@ -108,9 +108,9 @@ def _status(agent_config, _, args):
         print("Nothing to report.")
     else:
         # left-aligned service key, right-aligned counts.
-        flags = ["-", "", "", ""]
-        widths = [35, 10, 10, 10]
-        types = ["s", "s", "s", "s"]
+        flags = ["-", "", "", "", ""]
+        widths = [35, 10, 10, 10, 10]
+        types = ["s", "s", "s", "s", "s"]
         column_fmts = [
             "%" + "".join(e)
             for e in zip_longest(flags, map(str, widths), types)
@@ -125,6 +125,7 @@ def _status(agent_config, _, args):
                 state.get("pending_events", empty_dict).get("count", 0),
                 state.get("succeeded_events", empty_dict).get("count", 0),
                 state.get("failed_events", empty_dict).get("count", 0)
+                (1 if state.get("throttled", False) else 0)
             ))
 
 

--- a/pdagent/pdqueue.py
+++ b/pdagent/pdqueue.py
@@ -385,7 +385,7 @@ class PDQueue(PDQueueBase):
         e.g. if there are no erroneous events, there might be no "failed_events"
         entry.
 
-        Sample data returned:
+        Sample data returned (if per_service_key_snapshot == False):
         {
             "snapshot": {
                 "pending_events": {
@@ -407,6 +407,59 @@ class PDQueue(PDQueueBase):
                     "service_keys_count": 2
                 },
                 "throttled_service_keys_count": 1
+            },
+            "aggregate": {
+                "successful_events_count": 20,
+                "failed_events_count": 2,
+                "started_on": "2014-03-18T20:49:02Z"
+            }
+        }
+
+        Sample data returned (if per_service_key_snapshot == True):
+        {
+            "snapshot": {
+                "svckey1": {
+                    "pending_events": {
+                        "count": 3,
+                        "newest_age_secs": 15,
+                        "oldest_age_secs": 40,
+                        "service_keys_count": 1
+                    },
+                    "succeeded_events": {
+                        "count": 3,
+                        "newest_age_secs": 5,
+                        "oldest_age_secs": 35,
+                        "service_keys_count": 1
+                    },
+                    "failed_events": {
+                        "count": 3,
+                        "newest_age_secs": 25,
+                        "oldest_age_secs": 45,
+                        "service_keys_count": 1
+                    },
+                    "throttled": True
+                },
+                "svckey2": {
+                    "pending_events": {
+                        "count": 3,
+                        "newest_age_secs": 10,
+                        "oldest_age_secs": 35,
+                        "service_keys_count": 1
+                    },
+                    "succeeded_events": {
+                        "count": 3,
+                        "newest_age_secs": 2,
+                        "oldest_age_secs": 32,
+                        "service_keys_count": 1
+                    },
+                    "failed_events": {
+                        "count": 3,
+                        "newest_age_secs": 15,
+                        "oldest_age_secs": 35,
+                        "service_keys_count": 1
+                    },
+                    "throttled": False
+                },
             },
             "aggregate": {
                 "successful_events_count": 20,
@@ -464,7 +517,10 @@ class PDQueue(PDQueueBase):
                     self.backoff_info._current_retry_at.items():
                 if retry_at > now:
                     throttled_keys.add(key)
-            snapshot_stats["throttled_service_keys_count"] = len(throttled_keys)
+            if per_service_key_snapshot:
+                snapshot_stats[svc_key]["throttled"] = True
+            else:
+                snapshot_stats["throttled_service_keys_count"] = len(throttled_keys)
 
         stats = {
             "snapshot": snapshot_stats


### PR DESCRIPTION
when an integration key is throttled, the binary 'pd-queue status' failed with :
```
[root@sensu0103e2 ~]# pd-queue status
Service Key                           Pending   Success  In Error
=================================================================
XXXXXXXXXXXXXXXXXXXXX            0       224         0
XXXXXXXXXXXXXXXXXXXXX            0        12         0
XXXXXXXXXXXXXXXXXXXXX            0        19         0
XXXXXXXXXXXXXXXXXXXXX            0       724         0
XXXXXXXXXXXXXXXXXXXXX            0        73         0
XXXXXXXXXXXXXXXXXXXXX            0         2         0
XXXXXXXXXXXXXXXXXXXXX         8444        21         0
XXXXXXXXXXXXXXXXXXXXX            0        42         0
XXXXXXXXXXXXXXXXXXXXX            0         7         0
Traceback (most recent call last):
  File "/bin/pd-queue", line 147, in <module>
    main()
  File "/bin/pd-queue", line 135, in main
    args.func(load_agent_config(), parser, args)
  File "/bin/pd-queue", line 123, in _status
    state.get("pending_events", empty_dict).get("count", 0),
AttributeError: 'int' object has no attribute 'get'
```

This pull request fixes the issue, and introduce a new column 'Throttled' in the pd-queue status output, as illustrated below:
```
[root@sensu0103e2 ~]# pd-queue status
Service Key                           Pending   Success  In Error Throttled
===========================================================================
XXXXXXXXXXXXXXXXXXXXX            0       231         0         0
XXXXXXXXXXXXXXXXXXXXX            0        12         0         0
XXXXXXXXXXXXXXXXXXXXX            0        17         0         0
XXXXXXXXXXXXXXXXXXXXX            0         2         0         0
XXXXXXXXXXXXXXXXXXXXX            0       728         0         0
XXXXXXXXXXXXXXXXXXXXX            0        74         0         0
XXXXXXXXXXXXXXXXXXXXX            0         4         0         0
XXXXXXXXXXXXXXXXXXXXX         8170        58         0         0
XXXXXXXXXXXXXXXXXXXXX            0        44         0         1
XXXXXXXXXXXXXXXXXXXXX            0        37         0         0
```