### PR TITLE
Give user option to exit early in order to avoid issue with systemd.

### DIFF
--- a/build-linux/deb/postinst
+++ b/build-linux/deb/postinst
@@ -60,6 +60,17 @@ if [ "$1" = "configure" ]; then
 
     pycompile -p pdagent
 
+    # If you install pdagent in a container without systemd,
+    # but remnants of systemd exist even though they won't
+    # be used, like with ubuntu, the install will fail.
+    # Particularly annoying when building Docker images.
+    # Setting PDAGENT_SKIP_SERVICE_START=yes gives user the
+    # option to not start service after install to avoid
+    # this problem.
+    if [[ -z "${PDAGENT_SKIP_SERVICE_START}" ]]; then
+        exit 0
+    fi
+
     if which systemctl >/dev/null; then
         install_systemd
     else

--- a/build-linux/rpm/postinst
+++ b/build-linux/rpm/postinst
@@ -70,6 +70,17 @@ chmod -R a+r $INSTALL_PATH/root_certs
 # Compile module .py to .pyc
 python -m compileall -q -f "$INSTALL_PATH/"
 
+# If you install pdagent in a container without systemd,
+# but remnants of systemd exist even though they won't
+# be used, like with ubuntu, the install will fail.
+# Particularly annoying when building Docker images.
+# Setting PDAGENT_SKIP_SERVICE_START=yes gives user the
+# option to not start service after install to avoid
+# this problem.
+if [[ -z "${PDAGENT_SKIP_SERVICE_START}" ]]; then
+    exit 0
+fi
+
 if which systemctl >/dev/null; then
     install_systemd
 else


### PR DESCRIPTION
The script checks for the existence of `systemctl` to determine of presence of systemd, which is fine. However, there are cases like with the Ubuntu 20.04 docker image where systemd is technically present, but won't work. 

This modification allows the user to set an environment variable `PDAGENT_SKIP_SERVICE_START` in order to skip starting the service after the install. This is necessary, because if a start of pdagent's systemd service is attempted, then it will cause a failure. This is particularly annoying when building a Docker image. This change allows the user to avoid that problem.