### PR TITLE
Lock io-like version to prevent ruby 2.7 requirement

### DIFF
--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -37,6 +37,9 @@ RUN gem install -q --no-ri --no-rdoc -v 2.8.1 dotenv
 # Lock ffi version to prevent ruby 2.5 requirement
 RUN gem install -q --no-ri --no-rdoc -v 1.15.5 ffi
 
+# Lock io-like version to prevent ruby 2.7 requirement
+RUN gem install -q --no-ri --no-rdoc -v 0.3.1 io-like
+
 RUN gem install -q --no-ri --no-rdoc -v ${FPM_VERSION} fpm
 RUN apt-get install -y -q python${PYTHON_VERSION}
 RUN cd /lib/systemd/system/sysinit.target.wants/ \


### PR DESCRIPTION
This PR fixes the following error

```
$ make ubuntu

Step 28/35 : RUN gem install -q --no-ri --no-rdoc -v ${FPM_VERSION} fpm
 ---> Running in 17614b4d8a86
ERROR:  Error installing fpm:
	io-like requires Ruby version >= 2.7.0.
```